### PR TITLE
[GH-255] Taking into account linuxmint platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ v2.0.1 (unreleased)
 - [GH-234] /var/run/httpd/mod_fcgid directory now belongs to apache on Fedora/RHEL systems.
 - [GH-235] Removed `apache2::mpm_itk` which is not part of core and therefore should be its own cookbook
 - [GH-238] Bump service config syntax check guard timeout to 10 seconds
+- [GH-255] Taking into account linuxmint platform and associating linuxmint 17 with Apache 2.4
 
 v2.0.0 (2014-08-06)
 --------------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,8 @@ if node['platform'] == 'ubuntu' && node['platform_version'].to_f >= 13.10
   default['apache']['version'] = '2.4'
 elsif node['platform'] == 'debian' && node['platform_version'].to_f >= 8.0
   default['apache']['version'] = '2.4'
+elsif node['platform'] == 'linuxmint' && node['platform_version'].to_f >= 17.0
+  default['apache']['version'] = '2.4'
 elsif node['platform'] == 'redhat' && node['platform_version'].to_f >= 7.0
   default['apache']['version'] = '2.4'
 elsif node['platform'] == 'centos' && node['platform_version'].to_f >= 7.0
@@ -89,7 +91,7 @@ when 'suse', 'opensuse'
   end
   default['apache']['lib_dir']     = node['kernel']['machine'] =~ /^i[36]86$/ ? '/usr/lib/apache2' : '/usr/lib64/apache2'
   default['apache']['libexec_dir'] = node['apache']['lib_dir']
-when 'debian', 'ubuntu'
+when 'debian', 'ubuntu', 'linuxmint'
   default['apache']['package']     = 'apache2'
   default['apache']['perl_pkg']    = 'perl'
   default['apache']['apachectl']   = '/usr/sbin/apache2ctl'

--- a/metadata.rb
+++ b/metadata.rb
@@ -53,6 +53,7 @@ depends 'logrotate'
 
 supports 'debian'
 supports 'ubuntu'
+supports 'linuxmint'
 supports 'redhat'
 supports 'centos'
 supports 'fedora'

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -103,7 +103,7 @@ describe 'apache2::default' do
           expect(apacheconf).to_not notify('service[apache2]').to(:reload).immediately
         end
 
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it "creates #{property[:apache][:dir]}/envvars" do
             expect(chef_run).to create_template("#{property[:apache][:dir]}/envvars").with(
               :source => 'envvars.erb',

--- a/spec/modules/mod_apreq2_spec.rb
+++ b/spec/modules/mod_apreq2_spec.rb
@@ -37,7 +37,7 @@ describe 'apache2::mod_apreq2' do
             expect(package).to_not notify('execute[generate-module-list]').to(:nothing)
           end
         end
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it 'installs package libapache2-mod-apreq2' do
             expect(chef_run).to install_package('libapache2-mod-apreq2')
             expect(chef_run).to_not install_package('not_libapache2-mod-apreq2')

--- a/spec/modules/mod_auth_openid_spec.rb
+++ b/spec/modules/mod_auth_openid_spec.rb
@@ -21,7 +21,7 @@ describe 'apache2::mod_auth_openid' do
           stub_command("#{property[:apache][:binary]} -t").and_return(true)
         end
 
-        if %w(debian ubuntu suse opensuse).include?(platform)
+        if %w(debian ubuntu linuxmint suse opensuse).include?(platform)
           %w(automake make g++ apache2-prefork-dev libopkele-dev libopkele3 libtool).each do |package|
             it "installs package #{package}" do
               expect(chef_run).to install_package(package)

--- a/spec/modules/mod_fastcgi_spec.rb
+++ b/spec/modules/mod_fastcgi_spec.rb
@@ -15,7 +15,7 @@ describe 'apache2::mod_fastcgi' do
           stub_command("#{property[:apache][:binary]} -t").and_return(true)
         end
 
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it 'installs package libapache2-mod-fastcgi' do
             expect(chef_run).to install_package('libapache2-mod-fastcgi')
           end

--- a/spec/modules/mod_pagespeed_spec.rb
+++ b/spec/modules/mod_pagespeed_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-platforms = supported_platforms.select { |key, _| %w(debian ubuntu).include?(key) }
+platforms = supported_platforms.select { |key, _| %w(debian ubuntu linuxmint).include?(key) }
 
 describe 'apache2::mod_pagespeed' do
   platforms.each do |platform, versions|

--- a/spec/modules/mod_perl_spec.rb
+++ b/spec/modules/mod_perl_spec.rb
@@ -44,7 +44,7 @@ describe 'apache2::mod_perl' do
             expect(chef_run).to_not install_package('not_Apache2-Request')
           end
         end
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           %w(libapache2-mod-perl2 libapache2-request-perl apache2-mpm-prefork).each do |pkg|
             it "installs package #{pkg}" do
               expect(chef_run).to install_package(pkg)

--- a/spec/modules/mod_php5_spec.rb
+++ b/spec/modules/mod_php5_spec.rb
@@ -42,7 +42,7 @@ describe 'apache2::mod_php5' do
             expect(package).to_not notify('execute[generate-module-list]').to(:nothing)
           end
         end
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it 'installs package libapache2-mod-php5' do
             expect(chef_run).to install_package('libapache2-mod-php5')
             expect(chef_run).to_not install_package('not_libapache2-mod-php5')

--- a/spec/modules/mod_python_spec.rb
+++ b/spec/modules/mod_python_spec.rb
@@ -36,7 +36,7 @@ describe 'apache2::mod_python' do
             expect(package).to_not notify('execute[generate-module-list]').to(:nothing)
           end
         end
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it 'installs package libapache2-mod-python' do
             expect(chef_run).to install_package('libapache2-mod-python')
             expect(chef_run).to_not install_package('not_libapache2-mod-python')

--- a/spec/modules/mod_xsendfile_spec.rb
+++ b/spec/modules/mod_xsendfile_spec.rb
@@ -36,7 +36,7 @@ describe 'apache2::mod_xsendfile' do
             expect(package).to_not notify('execute[generate-module-list]').to(:nothing)
           end
         end
-        if %w(debian ubuntu).include?(platform)
+        if platform_family?('debian')
           it 'installs package libapache2-mod-xsendfile' do
             expect(chef_run).to install_package('libapache2-mod-xsendfile')
             expect(chef_run).to_not install_package('not_libapache2-mod-xsendfile')

--- a/templates/default/mods/ssl.conf.erb
+++ b/templates/default/mods/ssl.conf.erb
@@ -33,7 +33,7 @@
   #   Configure the pass phrase gathering process.
   #   The filtering dialog program (`builtin' is a internal
   #   terminal dialog) has to provide the pass phrase on stdout.
-<% if %w[ubuntu].include?(node['platform']) && node['apache']['version'] == '2.4' -%>
+<% if %w[ubuntu linuxmint].include?(node['platform']) && node['apache']['version'] == '2.4' -%>
   SSLPassPhraseDialog exec:/usr/share/apache2/ask-for-passphrase
 <% else -%>
   SSLPassPhraseDialog  builtin

--- a/test/fixtures/cookbooks/apache2_test/recipes/mod_authnz_ldap.rb
+++ b/test/fixtures/cookbooks/apache2_test/recipes/mod_authnz_ldap.rb
@@ -19,7 +19,7 @@
 directory '/var/cache/local/preseeding' do
   recursive true
   action :create
-  only_if { platform?('debian', 'ubuntu') }
+  only_if { platform_family?('debian') }
 end
 
 include_recipe 'openldap::server'

--- a/test/fixtures/cookbooks/apache2_test/recipes/mod_proxy_ajp.rb
+++ b/test/fixtures/cookbooks/apache2_test/recipes/mod_proxy_ajp.rb
@@ -28,7 +28,7 @@ end
 
 include_recipe 'tomcat::default'
 
-if platform?('debian', 'ubuntu')
+if platform_family?('debian')
   package 'tomcat6-examples' do
     action :install
   end


### PR DESCRIPTION
Updating the main file apache2.conf but also every other places where 'ubuntu' is used.

Some platform checks (debian & ubuntu & linuxmint) have been replaced by a platform_family check for forward compatibility and limit work for the next ubuntu-like distribution.
